### PR TITLE
feat: add ai triage observability logs

### DIFF
--- a/apps/api/src/features/triage/application/constants/ai-triage.constants.ts
+++ b/apps/api/src/features/triage/application/constants/ai-triage.constants.ts
@@ -5,10 +5,11 @@ export const AI_SENTIMENT_CONFIDENCE_THRESHOLD = 0.75;
 export const AI_DUPLICATE_SIMILARITY_THRESHOLD = 0.85;
 export const AI_RECENT_ISSUES_LIMIT = 15;
 const LLM_TIMEOUT_ENV_VAR = 'LLM_TIMEOUT';
-const LLM_PROVIDER_ENV_VAR = 'LLM_PROVIDER';
+export const LLM_PROVIDER_ENV_VAR = 'LLM_PROVIDER';
+export const LLM_MODEL_ENV_VAR = 'LLM_MODEL';
 export const LLM_LOG_RAW_RESPONSE_ENV_VAR = 'LLM_LOG_RAW_RESPONSE';
 export const LLM_RAW_TEXT_LOG_PREVIEW_CHARS = 2000;
-const DEFAULT_LLM_PROVIDER = 'ollama';
+export const DEFAULT_LLM_PROVIDER = 'ollama';
 const AI_TIMEOUT_DEFAULT_MS = 120000;
 const AI_TIMEOUT_OLLAMA_MS = 240000;
 const AI_TIMEOUT_GEMINI_MS = 120000;
@@ -72,3 +73,24 @@ export const AI_QUESTION_FALLBACK_CHECKLIST = [
   '- Describe expected behavior vs actual behavior.',
   '- Include relevant logs/errors from the API process.',
 ] as const;
+
+export const AI_TRIAGE_LOG_EVENT_STARTED = 'ai_triage_started';
+export const AI_TRIAGE_LOG_EVENT_COMPLETED = 'ai_triage_completed';
+export const AI_TRIAGE_LOG_EVENT_FAILED = 'ai_triage_failed';
+
+export const AI_TRIAGE_LOG_STATUS_STARTED = 'started';
+export const AI_TRIAGE_LOG_STATUS_COMPLETED = 'completed';
+export const AI_TRIAGE_LOG_STATUS_FAILED = 'failed';
+
+export const AI_TRIAGE_LOG_STEP_CLASSIFICATION = 'classification';
+export const AI_TRIAGE_LOG_STEP_DUPLICATE = 'duplicate';
+export const AI_TRIAGE_LOG_STEP_TONE = 'tone';
+export const AI_TRIAGE_LOG_STEPS = [
+  AI_TRIAGE_LOG_STEP_CLASSIFICATION,
+  AI_TRIAGE_LOG_STEP_DUPLICATE,
+  AI_TRIAGE_LOG_STEP_TONE,
+] as const;
+export type AiTriageLogStep = (typeof AI_TRIAGE_LOG_STEPS)[number];
+
+export const AI_TRIAGE_LOG_START_DURATION_MS = 0;
+export const AI_TRIAGE_LOG_UNKNOWN_VALUE = 'unknown';

--- a/apps/api/src/features/triage/application/services/ai-triage-governance-actions-context.service.ts
+++ b/apps/api/src/features/triage/application/services/ai-triage-governance-actions-context.service.ts
@@ -6,6 +6,7 @@ import type { QuestionResponseMetricsPort } from '../../../../shared/application
 interface Logger {
   debug?: (message: string, ...args: unknown[]) => void;
   info?: (message: string, ...args: unknown[]) => void;
+  error?: (message: string, ...args: unknown[]) => void;
 }
 
 interface IssuePayload {
@@ -20,6 +21,8 @@ export interface ApplyAiTriageGovernanceActionsInput {
   repositoryFullName: string;
   issue: IssuePayload;
   aiAnalysis: AiAnalysis;
+  llmProvider: string;
+  llmModel: string;
   repositoryReadme?: string;
   governanceGateway: GovernanceGateway;
   issueHistoryGateway: IssueHistoryGateway;
@@ -39,6 +42,8 @@ export interface AiTriageGovernanceActionsExecutionContext {
   repositoryFullName: string;
   issue: IssuePayload;
   aiAnalysis: AiAnalysis;
+  llmProvider: string;
+  llmModel: string;
   repositoryReadme?: string;
   governanceGateway: GovernanceGateway;
   issueHistoryGateway: IssueHistoryGateway;

--- a/apps/api/tests/features/triage/application/analyze-issue-with-ai.observability-logs.use-case.test.ts
+++ b/apps/api/tests/features/triage/application/analyze-issue-with-ai.observability-logs.use-case.test.ts
@@ -1,0 +1,202 @@
+import type { GovernanceGateway } from '../../../../src/features/triage/application/ports/governance-gateway.port';
+import type { IssueHistoryGateway } from '../../../../src/features/triage/application/ports/issue-history-gateway.port';
+import {
+  analyzeIssueWithAi,
+  type AnalyzeIssueWithAiInput,
+} from '../../../../src/features/triage/application/use-cases/analyze-issue-with-ai.use-case';
+import type { LLMGateway } from '../../../../src/shared/application/ports/llm-gateway.port';
+import {
+  AI_TRIAGE_LOG_EVENT_COMPLETED,
+  AI_TRIAGE_LOG_EVENT_FAILED,
+  AI_TRIAGE_LOG_EVENT_STARTED,
+  AI_TRIAGE_LOG_STATUS_COMPLETED,
+  AI_TRIAGE_LOG_STATUS_FAILED,
+  AI_TRIAGE_LOG_STATUS_STARTED,
+  AI_TRIAGE_LOG_STEPS,
+  type AiTriageLogStep,
+  LLM_MODEL_ENV_VAR,
+  LLM_PROVIDER_ENV_VAR,
+} from '../../../../src/features/triage/application/constants/ai-triage.constants';
+
+const createLlmGatewayMock = (): jest.Mocked<LLMGateway> => ({
+  generateJson: jest.fn().mockResolvedValue({
+    rawText: JSON.stringify({
+      classification: {
+        type: 'bug',
+        confidence: 0.95,
+        reasoning: 'The issue reports a reproducible software failure.',
+      },
+      duplicateDetection: {
+        isDuplicate: false,
+        originalIssueNumber: null,
+        similarityScore: 0.1,
+        hasExplicitOriginalIssueReference: false,
+      },
+      sentiment: {
+        tone: 'neutral',
+        reasoning: 'The report is neutral and technical.',
+      },
+    }),
+  }),
+});
+
+const createIssueHistoryGatewayMock = (): jest.Mocked<IssueHistoryGateway> => ({
+  findRecentIssues: jest.fn().mockResolvedValue([
+    {
+      number: 10,
+      title: 'Cannot login in Safari',
+      labels: ['kind/bug'],
+      state: 'open',
+    },
+  ]),
+  hasIssueCommentWithPrefix: jest.fn().mockResolvedValue(false),
+});
+
+const createGovernanceGatewayMock = (): jest.Mocked<GovernanceGateway> => ({
+  addLabels: jest.fn().mockResolvedValue(undefined),
+  removeLabel: jest.fn().mockResolvedValue(undefined),
+  createComment: jest.fn().mockResolvedValue(undefined),
+  logValidatedIssue: jest.fn().mockResolvedValue(undefined),
+});
+
+const createInput = (overrides: Partial<AnalyzeIssueWithAiInput> = {}): AnalyzeIssueWithAiInput => ({
+  action: 'opened',
+  repositoryFullName: 'org/repo',
+  issue: {
+    number: 42,
+    title: 'Login fails intermittently',
+    body: 'Users report intermittent auth failures in mobile browsers after one hour.',
+    labels: ['kind/bug'],
+  },
+  ...overrides,
+});
+
+const createLogger = (): { debug: jest.Mock; error: jest.Mock } => ({
+  debug: jest.fn(),
+  error: jest.fn(),
+});
+
+describe('AnalyzeIssueWithAiUseCase (Observability Logs)', () => {
+  it('should emit started and completed logs for each triage step', async () => {
+    // Arrange
+    const llmGateway = createLlmGatewayMock();
+    const issueHistoryGateway = createIssueHistoryGatewayMock();
+    const governanceGateway = createGovernanceGatewayMock();
+    const logger = createLogger();
+    const config = {
+      get: (key: string) => {
+        if (key === LLM_PROVIDER_ENV_VAR) {
+          return 'groq';
+        }
+        if (key === LLM_MODEL_ENV_VAR) {
+          return 'openai/gpt-oss-20b';
+        }
+        return undefined;
+      },
+      getBoolean: () => undefined,
+    };
+    const run = analyzeIssueWithAi({
+      llmGateway,
+      issueHistoryGateway,
+      governanceGateway,
+      logger,
+      config,
+    });
+
+    // Act
+    const result = await run(createInput());
+
+    // Assert
+    expect(result).toEqual({ status: 'completed' });
+    const startedEvents = logger.debug.mock.calls.filter(([message]) => message === AI_TRIAGE_LOG_EVENT_STARTED);
+    const completedEvents = logger.debug.mock.calls.filter(([message]) => message === AI_TRIAGE_LOG_EVENT_COMPLETED);
+    expect(startedEvents).toHaveLength(AI_TRIAGE_LOG_STEPS.length);
+    expect(completedEvents).toHaveLength(AI_TRIAGE_LOG_STEPS.length);
+
+    AI_TRIAGE_LOG_STEPS.forEach((step: AiTriageLogStep) => {
+      const startedContext = startedEvents.find(([, context]) => (context as { step?: string }).step === step)?.[1] as
+        | Record<string, unknown>
+        | undefined;
+      const completedContext = completedEvents.find(([, context]) => (context as { step?: string }).step === step)?.[1] as
+        | Record<string, unknown>
+        | undefined;
+
+      expect(startedContext).toEqual(
+        expect.objectContaining({
+          repositoryFullName: 'org/repo',
+          issueNumber: 42,
+          step,
+          status: AI_TRIAGE_LOG_STATUS_STARTED,
+          provider: 'groq',
+          model: 'openai/gpt-oss-20b',
+          durationMs: expect.any(Number),
+        }),
+      );
+      expect(completedContext).toEqual(
+        expect.objectContaining({
+          repositoryFullName: 'org/repo',
+          issueNumber: 42,
+          step,
+          status: AI_TRIAGE_LOG_STATUS_COMPLETED,
+          provider: 'groq',
+          model: 'openai/gpt-oss-20b',
+          durationMs: expect.any(Number),
+        }),
+      );
+    });
+  });
+
+  it('should emit failed logs for each triage step when LLM fails', async () => {
+    // Arrange
+    const llmGateway = createLlmGatewayMock();
+    llmGateway.generateJson.mockRejectedValueOnce(new Error('provider unavailable'));
+    const issueHistoryGateway = createIssueHistoryGatewayMock();
+    const governanceGateway = createGovernanceGatewayMock();
+    const logger = createLogger();
+    const config = {
+      get: (key: string) => {
+        if (key === LLM_PROVIDER_ENV_VAR) {
+          return 'groq';
+        }
+        if (key === LLM_MODEL_ENV_VAR) {
+          return 'openai/gpt-oss-20b';
+        }
+        return undefined;
+      },
+      getBoolean: () => undefined,
+    };
+    const run = analyzeIssueWithAi({
+      llmGateway,
+      issueHistoryGateway,
+      governanceGateway,
+      logger,
+      config,
+    });
+
+    // Act
+    const result = await run(createInput());
+
+    // Assert
+    expect(result).toEqual({ status: 'skipped', reason: 'ai_unavailable' });
+    const failedEvents = logger.debug.mock.calls.filter(([message]) => message === AI_TRIAGE_LOG_EVENT_FAILED);
+    expect(failedEvents).toHaveLength(AI_TRIAGE_LOG_STEPS.length);
+
+    AI_TRIAGE_LOG_STEPS.forEach((step: AiTriageLogStep) => {
+      const failedContext = failedEvents.find(([, context]) => (context as { step?: string }).step === step)?.[1] as
+        | Record<string, unknown>
+        | undefined;
+
+      expect(failedContext).toEqual(
+        expect.objectContaining({
+          repositoryFullName: 'org/repo',
+          issueNumber: 42,
+          step,
+          status: AI_TRIAGE_LOG_STATUS_FAILED,
+          provider: 'groq',
+          model: 'openai/gpt-oss-20b',
+          durationMs: expect.any(Number),
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Emit ai_triage_started/completed/failed logs per step with duration, provider, model
- Wire provider/model into triage action context
- Add coverage for observability log events

## Tests
- pnpm --filter api exec jest apps/api/tests/features/triage/application/analyze-issue-with-ai.observability-logs.use-case.test.ts
- pnpm --filter api lint
- pnpm --filter api test
