### PR TITLE
fix: retry gemini and ollama requests on TimeoutError

### DIFF
--- a/apps/api/src/shared/infrastructure/ai/adapters/gemini-llm.adapter.ts
+++ b/apps/api/src/shared/infrastructure/ai/adapters/gemini-llm.adapter.ts
@@ -1,6 +1,7 @@
 import type { LLMGateway } from '../../../application/ports/llm-gateway.port';
 import type { ConfigPort } from '../../../application/ports/config.port';
 import { createEnvConfig } from '../../config/env-config.adapter';
+import { isRetryableTimeoutError } from './retryable-timeout-error.guard';
 
 const DEFAULT_GEMINI_MODEL = 'gemini-1.5-flash';
 const DEFAULT_GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
@@ -100,8 +101,6 @@ const buildGeminiRequestBody = ({
 const isRetryableStatus = (status: number): boolean =>
   (GEMINI_RETRYABLE_STATUS_CODES as readonly number[]).includes(status);
 
-const isTimeoutError = (error: unknown): boolean => error instanceof Error && error.name === 'AbortError';
-
 const parseGeminiErrorResponse = async (response: Response): Promise<GeminiErrorResponse | undefined> => {
   try {
     return (await response.json()) as GeminiErrorResponse;
@@ -193,7 +192,7 @@ export const createGeminiLlmAdapter = (params: CreateGeminiLlmAdapterParams = {}
 
           return (await response.json()) as GeminiSuccessResponse;
         } catch (error: unknown) {
-          if (!isTimeoutError(error)) {
+          if (!isRetryableTimeoutError(error)) {
             throw error;
           }
 

--- a/apps/api/src/shared/infrastructure/ai/adapters/retryable-timeout-error.guard.ts
+++ b/apps/api/src/shared/infrastructure/ai/adapters/retryable-timeout-error.guard.ts
@@ -1,0 +1,11 @@
+const ABORT_ERROR_NAME = 'AbortError';
+const TIMEOUT_ERROR_NAME = 'TimeoutError';
+const RETRYABLE_TIMEOUT_ERROR_NAMES = [ABORT_ERROR_NAME, TIMEOUT_ERROR_NAME] as const;
+
+export const isRetryableTimeoutError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (RETRYABLE_TIMEOUT_ERROR_NAMES as readonly string[]).includes(error.name);
+};


### PR DESCRIPTION
## Contexto
Durante la revisión se detectó que la lógica de retry por timeout solo consideraba `AbortError`.

En Node.js 22, cuando se usa `AbortSignal.timeout(timeoutMs)`, los timeouts de `fetch` pueden propagarse como `TimeoutError`.
Esto hacía que algunos timeouts reales no entrasen en el branch de retry y fallasen al primer intento.

## Alcance de la corrección
Se corrigió el comportamiento en los adapters que sí implementan retry por timeout:
- `apps/api/src/shared/infrastructure/ai/adapters/gemini-llm.adapter.ts`
- `apps/api/src/shared/infrastructure/ai/adapters/ollama-llm.adapter.ts`

Además, se extrajo una guard compartida para evitar duplicación:
- `apps/api/src/shared/infrastructure/ai/adapters/retryable-timeout-error.guard.ts`

Nota: en esta base de código, `groq-llm.adapter.ts` no tiene retry por timeout equivalente; su retry actual es de fallback de salida estructurada (status 400 con mensaje específico del proveedor).

## Cambios implementados
1. Nueva guard `isRetryableTimeoutError(error)`:
- acepta `AbortError`
- acepta `TimeoutError`

2. Gemini/Ollama ahora usan esa guard en el catch del request con retry.

3. Tests nuevos (sin modificar casos previos):
- `should retry once when Gemini request times out with TimeoutError`
- `should retry once when Ollama request times out with TimeoutError`

## Evidencia TDD
### RED
Comando:
- `pnpm --filter api exec jest tests/shared/infrastructure/ai/adapters/gemini-llm.adapter.test.ts tests/shared/infrastructure/ai/adapters/ollama-llm.adapter.test.ts -t "times out with TimeoutError"`

Resultado:
- fallan ambos tests nuevos con `TimeoutError: Request timed out` (no se ejecutaba retry).

### GREEN
Comando (mismo test focalizado):
- `pnpm --filter api exec jest tests/shared/infrastructure/ai/adapters/gemini-llm.adapter.test.ts tests/shared/infrastructure/ai/adapters/ollama-llm.adapter.test.ts -t "times out with TimeoutError"`

Resultado:
- tests en verde en Gemini y Ollama.

### Validación completa
- `pnpm --filter api lint` ✅
- `pnpm --filter api test` ✅
- `pnpm lint` ✅
- `pnpm test` ✅

## Impacto
- Se mantiene la semántica de reintento único en timeouts.
- Se corrige el comportamiento real en Node 22 para timeouts de `fetch`.
- No hay cambios de contrato público ni de arquitectura hexagonal.

## Checklist
- [x] Cambio implementado con TDD (RED -> GREEN -> REFACTOR)
- [x] Sin `any`, tipado estricto mantenido
- [x] Lint y test del workspace `api` en verde
- [x] Lint y test globales en verde